### PR TITLE
Bookstore book removal bug fix

### DIFF
--- a/src/main/java/models/Bookstore.java
+++ b/src/main/java/models/Bookstore.java
@@ -62,8 +62,10 @@ public class Bookstore {
             }
         }
         if (bookFound != null) {
-            this.books.remove(bookFound);
-            bookFound.removeBookstore();
+            if (bookFound.getAvailable()) {
+                this.books.remove(bookFound);
+                bookFound.removeBookstore();
+            }
         }
     }
 }

--- a/src/main/resources/templates/editBookstore.html
+++ b/src/main/resources/templates/editBookstore.html
@@ -38,7 +38,7 @@
                     <td th:text="${book.getId()}"></td>
                     <td th:text="${book.getName()}"></td>
                     <td>
-                        <form action="#" th:action="@{/removeBook}" method="post">
+                        <form th:if="${book.getAvailable()}" action="#" th:action="@{/removeBook}" method="post">
                             <input type="hidden" name="bookstoreId" th:value="${bookstore.getId()}" />
                             <input type="hidden" name="bookId" th:value="${book.getId()}" />
                             <input type="submit" value="Remove Book"/>

--- a/src/test/java/BookstoreTest.java
+++ b/src/test/java/BookstoreTest.java
@@ -32,12 +32,12 @@ public class BookstoreTest {
     }
 
     /**
-     * Test the removeBook() method in Book.
+     * Test the removeBook() method in Bookstore when Book is available.
      *
      * Expected condition: The Bookstore no longer contains the Book and the Book no longer has a Bookstore
      */
     @Test
-    public void testRemoveBook(){
+    public void testRemoveBookWhenAvailable(){
         Book book = new Book("Test Book", "1234567890", "picture.jpeg", "book for testing purposes", "George Orwell", "96024 publishing");
         book.setId(1L);
 
@@ -46,5 +46,23 @@ public class BookstoreTest {
 
         assert(!this.bookstore.getBooks().contains(book));
         assert(book.getBookstore() == null);
+    }
+
+    /**
+     * Test the removeBook() method in Bookstore when Book is not available.
+     *
+     * Expected condition: The Bookstore still contains the Book and the Book
+     */
+    @Test
+    public void testRemoveBookWhenNotAvailable(){
+        Book book = new Book("Test Book", "1234567890", "picture.jpeg", "book for testing purposes", "George Orwell", "96024 publishing");
+        book.setId(1L);
+        book.setAvailable(false);
+
+        this.bookstore.addBook(book);
+        this.bookstore.removeBookById(1L);
+
+        assert(this.bookstore.getBooks().contains(book));
+        assert(book.getBookstore() == this.bookstore);
     }
 }


### PR DESCRIPTION
Bookstore
 - only allow for removal of a book if it is available, if it is not available (sold) bookstore is unable to remove it (this is because this means a book has been sold, and we'd like to keep reference of where the book was sold from)

 editBookstore.html
 - only provide 'Remove' button for bookstores if the Book is available

 BookstoreTest
 - test removeBook() for condition when a book is and is not available