### PR TITLE
Port Bookstore removeBook() changes to milestone2

### DIFF
--- a/src/main/java/models/Bookstore.java
+++ b/src/main/java/models/Bookstore.java
@@ -62,8 +62,10 @@ public class Bookstore {
             }
         }
         if (bookFound != null) {
-            this.books.remove(bookFound);
-            bookFound.removeBookstore();
+            if (bookFound.getAvailable()) {
+                this.books.remove(bookFound);
+                bookFound.removeBookstore();
+            }
         }
     }
 }

--- a/src/main/resources/templates/editBookstore.html
+++ b/src/main/resources/templates/editBookstore.html
@@ -35,7 +35,7 @@
                     <td th:text="${book.getId()}"></td>
                     <td th:text="${book.getName()}"></td>
                     <td>
-                        <form action="#" th:action="@{/removeBook}" method="post">
+                        <form th:if="${book.getAvailable()}" action="#" th:action="@{/removeBook}" method="post">
                             <input type="hidden" name="bookstoreId" th:value="${bookstore.getId()}" />
                             <input type="hidden" name="bookId" th:value="${book.getId()}" />
                             <input type="submit" value="Remove Book"/>

--- a/src/main/resources/templates/shopBookstore.html
+++ b/src/main/resources/templates/shopBookstore.html
@@ -7,7 +7,7 @@
 <body>
 <form action="#" th:action="@{/viewCustomer}" method="post">
     <input type="hidden" name="customerId" th:value="${customer.getId()}" />
-    <input type="submit" value="Back to BookstoreOwner"/>
+    <input type="submit" value="Back to Customer"/>
 </form>
 <p th:text="'BookStore ID: ' + ${bookstore.getId()}" />
 <p th:text="'BookStore Owner: ' + ${bookstore.getBookstoreOwner().getName()}" />

--- a/src/test/java/BookstoreTest.java
+++ b/src/test/java/BookstoreTest.java
@@ -32,12 +32,12 @@ public class BookstoreTest {
     }
 
     /**
-     * Test the removeBook() method in Book.
+     * Test the removeBook() method in Bookstore when Book is available.
      *
      * Expected condition: The Bookstore no longer contains the Book and the Book no longer has a Bookstore
      */
     @Test
-    public void testRemoveBook(){
+    public void testRemoveBookWhenAvailable(){
         Book book = new Book("Test Book", "1234567890", "picture.jpeg", "book for testing purposes", "George Orwell", "96024 publishing");
         book.setId(1L);
 
@@ -46,5 +46,24 @@ public class BookstoreTest {
 
         assert(!this.bookstore.getBooks().contains(book));
         assert(book.getBookstore() == null);
+    }
+
+
+    /**
+     * Test the removeBook() method in Bookstore when Book is not available.
+     *
+     * Expected condition: The Bookstore still contains the Book and the Book
+     */
+    @Test
+    public void testRemoveBookWhenNotAvailable(){
+        Book book = new Book("Test Book", "1234567890", "picture.jpeg", "book for testing purposes", "George Orwell", "96024 publishing");
+        book.setId(1L);
+        book.setAvailable(false);
+
+        this.bookstore.addBook(book);
+        this.bookstore.removeBookById(1L);
+
+        assert(this.bookstore.getBooks().contains(book));
+        assert(book.getBookstore() == this.bookstore);
     }
 }


### PR DESCRIPTION
**The purpose of this pr is to have these changes in milestone2 just in case the Auth branch is not deployable on Heroku in time**
- When removing a Book, a Book can only be removed when it is Available. This means a Book that has been sold cannot be removed (this maintains the origin of where a book was bought "forever")
- Updated tests accordingly
- on the shopBookstore page correct name of back link